### PR TITLE
add comment for CR27

### DIFF
--- a/obpp3.json
+++ b/obpp3.json
@@ -2179,7 +2179,8 @@
         {
             "id": "OBPPV3/CR27",
             "description": "Blockchain data is queried via a method that matches a fraction of the blockchain beyond the addresses belonging to the wallet",
-            "nonce-id": "16b6ab28cba33110aebdac4a1c1309a5c31a599f31e641d9a46d718f1ad31db1"
+            "nonce-id": "16b6ab28cba33110aebdac4a1c1309a5c31a599f31e641d9a46d718f1ad31db1",
+            "comment": "This criterion may be met e.g. by the use of bloom or prefix filters for querying balance data"
         },
         {
             "id": "OBPPV3/CR28",


### PR DESCRIPTION
add comment for CR27
(16b6ab28cba33110aebdac4a1c1309a5c31a599f31e641d9a46d718f1ad31db1)

Otherwise, I’m happy that the wording for CR26
(bba9be9cd221ff2b40afa74dcc424d420fb30120f2c0a0f007bdd07c66f1c054 ) and
CR27 (16b6ab28cba33110aebdac4a1c1309a5c31a599f31e641d9a46d718f1ad31db1)
suit the spirit of what was discussed in
https://github.com/OpenBitcoinPrivacyProject/wallet-ratings/issues/103
