### PR TITLE
Add new criteria CR130 and CR131 to satisfy CM15 under two attacks

### DIFF
--- a/obpp3.json
+++ b/obpp3.json
@@ -486,7 +486,25 @@
                             "numeral": "1",
                             "id": "OBPPV3/CM15",
                             "description": "Introduce random delays before introducing new transactions to the network",
-                            "effectiveness": 0
+                            "effectiveness": 0,
+                            "criteria-groups": [
+                                {
+                                    "criteria": [
+                                        {
+                                            "numeral": "a",
+                                            "id": "OBPPV3/CR130",
+                                            "description": "The wallet client waits for a random amount of time before introducing the transaction to the Bitcoin P2P network",
+                                            "effectiveness": 0
+                                        },
+                                        {
+                                            "numeral": "b",
+                                            "id": "OBPPV3/CR131",
+                                            "description": "The wallet provider waits for a random amount of time before introducing the transaction to the Bitcoin P2P network",
+                                            "effectiveness": 0
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ]
                 }
@@ -991,7 +1009,25 @@
                             "numeral": "1",
                             "id": "OBPPV3/CM15",
                             "description": "Introduce random delays before introducing new transactions to the network",
-                            "effectiveness": 0
+                            "effectiveness": 0,
+                            "criteria-groups": [
+                                {
+                                    "criteria": [
+                                        {
+                                            "numeral": "a",
+                                            "id": "OBPPV3/CR130",
+                                            "description": "The wallet client waits for a random amount of time before introducing the transaction to the Bitcoin P2P network",
+                                            "effectiveness": 0
+                                        },
+                                        {
+                                            "numeral": "b",
+                                            "id": "OBPPV3/CR131",
+                                            "description": "The wallet provider waits for a random amount of time before introducing the transaction to the Bitcoin P2P network",
+                                            "effectiveness": 0
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ]
                 }
@@ -2513,6 +2549,16 @@
             "id": "OBPPV3/CR122",
             "description": "The wallet client cryptographically verifies all packaged software updates with a pinned public key before automatically updating software",
             "nonce-id": "f09d7dcb1f36adec20de3b0e60b5c6d27bd6ac64547b5a9ce67f2858b3e55cdf"
+        },
+        {
+            "id": "OBPPV3/CR130",
+            "description": "The wallet client waits for a random amount of time before introducing the transaction to the Bitcoin P2P network",
+            "nonce-id": "3780e065130b7921506e488ced61027786ad342f453af04291ee321d9cdd4f75"
+        },
+        {
+            "id": "OBPPV3/CR131",
+            "description": "The wallet provider waits for a random amount of time before introducing the transaction to the Bitcoin P2P network",
+            "nonce-id": "ad027b3771d9eca1af2ff21666d3c3eacb1d340b984c36c73f225f437970e8c9"
         }
     ],
     "criteria-categories": [


### PR DESCRIPTION
Added CR130
(3780e065130b7921506e488ced61027786ad342f453af04291ee321d9cdd4f75) and
CR131 (ad027b3771d9eca1af2ff21666d3c3eacb1d340b984c36c73f225f437970e8c9)

Listed them both under countermeasure CM15
(ee2a22b5ad3fe15ae7430e262423c48ceeb1fcb3f2141534c08279814c76c71f)
which is listed under both attacks
76b0b33bbb8f2cd3bf86de1d4c14b178203af5fd7b57f6bd3f66b317590fb384 and
f62d0ecf74cbb379fcde438a97a52d08eb79b07acde409e47b1dbcf9c814d114.

This is per
https://github.com/OpenBitcoinPrivacyProject/wallet-ratings/issues/73
