### PR TITLE
Add CR140 and list under CM20 in two attacks

### DIFF
--- a/obpp3.json
+++ b/obpp3.json
@@ -622,6 +622,12 @@
                                             "id": "OBPPV3/CR32",
                                             "description": "Client provides a visual indication if outgoing transactions are not being routed through an anonymizing network, including IP address information",
                                             "effectiveness": 0
+                                        },
+                                        {
+                                            "numeral": "c",
+                                            "id": "OBPPV3/CR140",
+                                            "description": "A non-zero percentage of transactions broadcast over a network by the wallet client do not originate from the user",
+                                            "effectiveness": 0
                                         }
                                     ]
                                 }
@@ -682,7 +688,19 @@
                             "numeral": "2",
                             "id": "OBPPV3/CM20",
                             "description": "Route outgoing transactions via a method that does not reveal the IP address of the sender",
-                            "effectiveness": 0
+                            "effectiveness": 0,
+                            "criteria-groups": [
+                                {
+                                    "criteria": [
+                                        {
+                                            "numeral": "a",
+                                            "id": "OBPPV3/CR140",
+                                            "description": "A non-zero percentage of transactions broadcast over a network by the wallet client do not originate from the user",
+                                            "effectiveness": 0
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ]
                 },
@@ -2513,6 +2531,12 @@
             "id": "OBPPV3/CR122",
             "description": "The wallet client cryptographically verifies all packaged software updates with a pinned public key before automatically updating software",
             "nonce-id": "f09d7dcb1f36adec20de3b0e60b5c6d27bd6ac64547b5a9ce67f2858b3e55cdf"
+        },
+        {
+            "id": "OBPPV3/CR140",
+            "description": "A non-zero percentage of transactions broadcast over a network by the wallet client do not originate from the user",
+            "nonce-id": "fcd6d8436c96e62a34becae0c873b31b177654ce6a6c709cc42ab9577ac3d640",
+            "comment": "This criterion is measured based on the percentage. This behavior is typically demonstrated by full node clients connected directly to the Bitcoin P2P network"
         }
     ],
     "criteria-categories": [


### PR DESCRIPTION
Added CR140
(fcd6d8436c96e62a34becae0c873b31b177654ce6a6c709cc42ab9577ac3d640).

Listed under CM20
(797090dd00d11157408f5c11bc4d55bcf95a281fae925f732900edafbb53e096)
under two attacks,
9e8d656ba62759f3afe0534b7bd7c2bfd060755ef24a306d6b4f7801bb265f33 and
96d8d118a8a65aa8dbad15dbfd78365f7cda16e4bfa7ceeabdc1b5cd7e92a2f9.
