### PR TITLE
#153 re-list blinded coinjoin criterion

### DIFF
--- a/obpp3.json
+++ b/obpp3.json
@@ -1213,7 +1213,7 @@
                                         {
                                             "numeral": "c",
                                             "id": "OBPPV3/CR48",
-                                            "description": "Mixing is secure against correlation attacks by the facilitator",
+                                            "description": "The facilitator of the mix does not have an increased ability to reverse the mix beyond the mix participants",
                                             "effectiveness": 0
                                         }
                                     ]
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "OBPPV3/CR48",
-            "description": "Mixing is secure against correlation attacks by the facilitator",
+            "description": "The facilitator of the mix does not have an increased ability to reverse the mix beyond the mix participants",
             "nonce-id": "0f2c4a66316a42c998ea5ba46c0ceca0595ee53c66959a8e4a6f934a6f75918b"
         },
         {

--- a/obpp3.json
+++ b/obpp3.json
@@ -1209,6 +1209,12 @@
                                             "id": "OBPPV3/CR30",
                                             "description": "Number of clicks required by user to route outgoing transactions through an anonymizing network",
                                             "effectiveness": 0
+                                        },
+                                        {
+                                            "numeral": "c",
+                                            "id": "OBPPV3/CR48",
+                                            "description": "Mixing is secure against correlation attacks by the facilitator",
+                                            "effectiveness": 0
                                         }
                                     ]
                                 }


### PR DESCRIPTION
This removes  warning from validate_json.py output.
